### PR TITLE
Diet failed - Attempt 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 trie-rs = "0.4"
+louds-rs = "0.7"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,14 @@ edition = "2024"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+trie-rs = "0.4"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 ahash = "0.8"
 regex = "1"
 okkhor = { version = "0.7", features = ["regex"] }
+peak_alloc = "0.2"
 
 [[bench]]
 name = "suggestions"

--- a/examples/alloc.rs
+++ b/examples/alloc.rs
@@ -1,0 +1,14 @@
+use upodesh::suggest::Suggest;
+use peak_alloc::PeakAlloc;
+
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+fn main() {
+    let suggest = Suggest::new();
+
+    let current_mem = PEAK_ALLOC.current_usage_as_mb();
+	println!("This program currently uses {} MB of RAM.", current_mem);
+	let peak_mem = PEAK_ALLOC.peak_usage_as_mb();
+	println!("The max amount that was used {} MB.", peak_mem);
+}

--- a/src/suggest.rs
+++ b/src/suggest.rs
@@ -18,6 +18,8 @@ pub struct Suggest {
     patterns: HashMap<String, Block>,
     patterns_trie: Trie,
     words: Trie,
+    test_words: trie_rs::Trie<u8>,
+    test_patterns: trie_rs::Trie<u8>,
     common_suffixes: Vec<String>,
 }
 
@@ -28,15 +30,36 @@ impl Suggest {
         let common_data = include_bytes!("../data/source-common-patterns.json");
 
         let patterns: HashMap<String, Block> = serde_json::from_slice(patterns_data).unwrap();
-        let patterns_trie = Trie::from_strings(patterns.keys().map(|s| s.as_str()));
-        let words = Trie::from_strings(words_data.lines().map(|s| s.trim()));
+        // let patterns_trie = Trie::from_strings(patterns.keys().map(|s| s.as_str()));
+        let patterns_trie = Trie::new();
+
+        // let words = Trie::from_strings(words_data.lines().map(|s| s.trim()));
+        let words = Trie::new();
         let common_suffixes = serde_json::from_slice(common_data).unwrap();
+
+        let mut builder = trie_rs::TrieBuilder::new();
+
+        for word in words_data.lines() {
+            builder.push(word.trim());
+        }
+
+        let test_words = builder.build();
+
+        let mut builder = trie_rs::TrieBuilder::new();
+
+        for pattern in patterns.keys() {
+            builder.push(pattern);
+        }
+
+        let test_patterns = builder.build();
 
         Suggest {
             patterns,
             patterns_trie,
             words,
             common_suffixes,
+            test_words,
+            test_patterns,
         }
     }
 

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -54,7 +54,7 @@ pub struct Trie {
 }
 
 impl Trie {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Trie {
             root: TrieNode::new(),
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,6 @@
+use louds_rs::LoudsNodeNum;
+use trie_rs::{inc_search::{IncSearch, Position}, Trie};
+
 pub fn fix_string(s: &str) -> String {
     let s = s.trim();
     let mut prev = ' ';
@@ -15,6 +18,71 @@ pub fn fix_string(s: &str) -> String {
     }
 
     result
+}
+
+pub fn match_longest_common_prefix<'a>(trie: &Trie<u8>, prefix: &'a str) -> (&'a str, &'a str, bool) {
+    if prefix.is_empty() {
+        return ("", "", false);
+    }
+
+    let mut search = trie.inc_search();
+
+    match search.query_until(prefix) {
+        Ok(a) => {
+            (&prefix, "", a.is_match())
+        }
+        Err(e) => {
+            let matched = &prefix[0..e];
+            let remaining = &prefix[e..];
+            (matched, remaining, false)
+        }
+    }
+}
+
+pub struct MatchableNode<'a> {
+    trie: &'a Trie<u8>,
+    pos: LoudsNodeNum,
+    complete: bool,
+}
+
+impl<'a> MatchableNode<'a> {
+    pub fn from(trie: &'a Trie<u8>) -> Self {
+        Self {
+            trie,
+            pos: LoudsNodeNum(1),
+            complete: false,
+        }
+    }
+
+    pub fn get_matching_node(&self, prefix: &str) -> Option<Self> {
+        let mut m = IncSearch::resume(&self.trie.0, self.pos);
+
+        match m.query_until(prefix) {
+            Ok(a) => {
+                if a.is_match() {
+                    Some(Self {
+                        trie: self.trie,
+                        pos: Position::from(m),
+                        complete: true,
+                    })
+                } else {
+                    Some(MatchableNode { trie: self.trie, pos: Position::from(m), complete: false })
+                }
+            },
+            Err(_) => {
+                None
+            }
+        }
+    }
+
+    pub fn get_word(&self) -> Option<String> {
+        if self.complete {
+            let search = IncSearch::resume(&self.trie.0, self.pos);
+            Some(search.prefix())
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Tried to use the [`trie-rs`](https://crates.io/crates/trie-rs) crate, although it consumes only 5MB of memory space, we get a huge amount of performance penalty:


Variant | upodesh (µs) | regex (µs) | Comparison
-- | -- | -- | --
a | 23,251 | 193.89 | ~125× slower
arO | 28,560 | 246.94 | ~116× slower
bistari | 2,580.5 | 354.22 | ~7.28× slower

🥲 

Maybe we'll have to modify the crate to our needs.

cc @mugli @gulshan 

#3 