### PR TITLE
Diet failed - Attempt 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,16 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+fst = "0.4"
+okkhor = { version = "0.7", features = ["regex"] }
+regex = "1"
+regex-automata = { version = "0.4" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 ahash = "0.8"
-regex = "1"
-okkhor = { version = "0.7", features = ["regex"] }
 
 [[bench]]
 name = "suggestions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,15 @@ edition = "2024"
 [dependencies]
 fst = "0.4"
 okkhor = { version = "0.7", features = ["regex"] }
-regex = "1"
-regex-automata = { version = "0.4" }
+regex-automata = { version = "0.4", features = ["dfa-search"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.6", features = ["html_reports"] }
 ahash = "0.8"
+peak_alloc = "0.2"
+regex = "1"
 
 [[bench]]
 name = "suggestions"

--- a/benches/suggestions.rs
+++ b/benches/suggestions.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
+use std::hint::black_box;
 
 use ahash::RandomState;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 use okkhor::parser::Parser;
 use regex::Regex;
 
-use upodesh::suggest::Suggest;
+use upodesh::{regex::RegexSuggest, suggest::Suggest};
 
 fn upodesh_benchmark(c: &mut Criterion) {
     let suggest = Suggest::new();
@@ -15,6 +16,18 @@ fn upodesh_benchmark(c: &mut Criterion) {
         b.iter(|| suggest.suggest(black_box("arO")))
     });
     c.bench_function("upodesh bistari", |b| {
+        b.iter(|| suggest.suggest(black_box("bistari")))
+    });
+}
+
+fn upodesh_fst_benchmark(c: &mut Criterion) {
+    let mut suggest = RegexSuggest::new();
+
+    c.bench_function("upodesh-fst a", |b| b.iter(|| suggest.suggest(black_box("a"))));
+    c.bench_function("upodesh-fst arO", |b| {
+        b.iter(|| suggest.suggest(black_box("arO")))
+    });
+    c.bench_function("upodesh-fst bistari", |b| {
         b.iter(|| suggest.suggest(black_box("bistari")))
     });
 }
@@ -82,5 +95,5 @@ fn regex_benchmark(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, upodesh_benchmark, regex_benchmark);
+criterion_group!(benches, upodesh_benchmark, upodesh_fst_benchmark, regex_benchmark);
 criterion_main!(benches);

--- a/examples/alloc-fst.rs
+++ b/examples/alloc-fst.rs
@@ -1,0 +1,14 @@
+use upodesh::regex::RegexSuggest;
+use peak_alloc::PeakAlloc;
+
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+fn main() {
+    let suggest = RegexSuggest::new();
+
+    let current_mem = PEAK_ALLOC.current_usage_as_mb();
+	println!("This program currently uses {} MB of RAM.", current_mem);
+	let peak_mem = PEAK_ALLOC.peak_usage_as_mb();
+	println!("The max amount that was used {} MB.", peak_mem);
+}

--- a/src/automation.rs
+++ b/src/automation.rs
@@ -1,0 +1,47 @@
+use regex_automata::{dfa::{dense::DFA, Automaton}, util::{primitives::StateID, start::Config}, Anchored};
+
+pub struct DfaFstAutomaton(DFA<Vec<u32>>);
+
+impl DfaFstAutomaton {
+    pub fn new(regex: &str) -> Self {
+        let dfa = DFA::new(regex).unwrap();
+        Self(dfa)
+    }
+}
+
+impl fst::Automaton for DfaFstAutomaton {
+    type State = StateID;
+
+    #[inline]
+    fn start(&self) -> Self::State {
+        let config = Config::new().anchored(Anchored::Yes);
+
+        self.0.start_state(&config).unwrap()
+    }
+
+    #[inline]
+    fn is_match(&self, state: &Self::State) -> bool {
+        self.0.is_match_state(*state)
+    }
+
+    #[inline]
+    fn can_match(&self, state: &Self::State) -> bool {
+        !self.0.is_dead_state(*state)
+    }
+
+    #[inline]
+    fn accept_eof(&self, state: &StateID) -> Option<StateID> {
+        if self.0.is_match_state(*state) {
+            return Some(*state);
+        }
+        Some(self.0.next_eoi_state(*state))
+    }
+
+    #[inline]
+    fn accept(&self, state: &Self::State, byte: u8) -> Self::State {
+        if self.0.is_match_state(*state) {
+            return *state;
+        }
+        self.0.next_state(*state, byte)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 mod trie;
 mod utils;
 pub mod suggest;
+pub mod regex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod trie;
 mod utils;
+mod automation;
 pub mod suggest;
 pub mod regex;

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,0 +1,47 @@
+use fst::{Set, SetBuilder};
+use okkhor::parser::Parser;
+use regex::Regex;
+
+
+struct RegexSuggest {
+    parser: Parser,
+    regex: String,
+    words: Set<Vec<u8>>,
+}
+
+impl RegexSuggest {
+    pub fn new() -> Self {
+        let list = include_str!("../data/source-words.txt");
+
+        let mut list = list.lines().map(|s| s.trim()).collect::<Vec<_>>();
+
+        list.sort();
+
+        let words = Set::from_iter(list).unwrap();
+        
+        Self {
+            parser: Parser::new_regex(),
+            regex: String::with_capacity(1024),
+            words,
+        }
+    }
+
+    pub fn suggest(&mut self, input: &str) -> Vec<String> {
+        self.parser.convert_regex_into(input, &mut self.regex);
+        let rgx = Regex::new(&self.regex).unwrap();
+
+        let r = self.words.search(rgx);
+
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_loading() {
+        let suggest = RegexSuggest::new();
+    }
+}

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,9 +1,10 @@
-use fst::{Set, SetBuilder};
+use fst::{IntoStreamer, Set};
 use okkhor::parser::Parser;
-use regex::Regex;
+
+use crate::automation::DfaFstAutomaton;
 
 
-struct RegexSuggest {
+pub struct RegexSuggest {
     parser: Parser,
     regex: String,
     words: Set<Vec<u8>>,
@@ -28,11 +29,11 @@ impl RegexSuggest {
 
     pub fn suggest(&mut self, input: &str) -> Vec<String> {
         self.parser.convert_regex_into(input, &mut self.regex);
-        let rgx = Regex::new(&self.regex).unwrap();
+        let rgx = DfaFstAutomaton::new(&self.regex);
 
-        let r = self.words.search(rgx);
+        let words = self.words.search(rgx).into_stream().into_strs().unwrap();
 
-        todo!()
+        words
     }
 }
 
@@ -42,6 +43,8 @@ mod tests {
 
     #[test]
     fn test_loading() {
-        let suggest = RegexSuggest::new();
+        let mut suggest = RegexSuggest::new();
+
+        assert_eq!(suggest.suggest("shari"), ["শ\u{9be}রি", "শ\u{9be}রী", "শ\u{9be}ড়ি", "শ\u{9be}ড়ী", "স\u{9be}রি", "স\u{9be}রী", "স\u{9be}ড়ি", "স\u{9be}ড়ী"]);
     }
 }


### PR DESCRIPTION
This was an attempt to use the `fst` crate to represent the dictionary and search the fst using regex. The `fst` provides significant memory usage reduction; only 1 MB is needed to represent the 3.8 MB dictionary compared to the current Trie representation, which uses 145 MB. But the downside is that searching with regexes is tremendously slow compared to current implementation with trie based search.

Mode | upodesh Time (µs) | upodesh-fst Time (µs) | Slowdown Factor (fst vs baseline) 
-- | -- | -- | -- 
a | 2.1615 | 104.86 | ~48.5× slower 
arO | 7.0134 | 261.75 | ~37.3× slower 
bistari | 4.6440 | 402.60 | ~86.6× slower 

<details>
upodesh a               time:   [2.1604 µs 2.1615 µs 2.1625 µs]
                        change: [−20.775% −20.677% −20.575%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low severe
  3 (3.00%) high mild
  4 (4.00%) high severe

upodesh arO             time:   [7.0103 µs 7.0134 µs 7.0167 µs]
                        change: [−27.864% −27.793% −27.726%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

upodesh bistari         time:   [4.6418 µs 4.6440 µs 4.6464 µs]
                        change: [−24.130% −24.050% −23.972%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

upodesh-fst a           time:   [104.81 µs 104.86 µs 104.92 µs]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

upodesh-fst arO         time:   [261.58 µs 261.75 µs 261.93 µs]
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

upodesh-fst bistari     time:   [400.92 µs 402.60 µs 404.08 µs]

regex a                 time:   [195.83 µs 195.90 µs 195.98 µs]
                        change: [+0.9174% +1.0273% +1.1363%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

regex arO               time:   [247.07 µs 247.50 µs 247.93 µs]
                        change: [−0.4496% −0.2532% −0.0679%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe

regex bistari           time:   [358.10 µs 358.50 µs 358.85 µs]
                        change: [+0.7364% +0.9580% +1.1805%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
</details>


#3 